### PR TITLE
Update config.jsonc

### DIFF
--- a/waybar/config.jsonc
+++ b/waybar/config.jsonc
@@ -9,10 +9,10 @@
 [
 	/* BAR 1 */
 	{
-		"include": "/home/sch/.config/waybar/modules.jsonc",
+		"include": "/home/$HOME/.config/waybar/modules.jsonc",
 		"height": 31,
 		"layer": "top",
-		"output": "HDMI-A-1",
+		// "output": "HDMI-A-1",
 		"mode": "dock",
 		"exclusive": true,
 		"passtrough": false,
@@ -46,8 +46,8 @@
 		]
 	},
 	/* BAR 2 */
-	{
-		"include": "/home/sch/.config/waybar/modules.jsonc",
+	/* {
+		"include": "/home/$HOME/.config/waybar/modules.jsonc",
 		"height": 31,
 		"layer": "top",
 		"output": "DP-2",
@@ -85,4 +85,5 @@
 			"tray"
 		]
 	}
+*/
 ]


### PR DESCRIPTION
### Fix hardcoded Waybar module path and disable user-specific configuration

#### Summary
This pull request removes user-specific and hardware-specific assumptions from the Waybar configuration to improve portability across systems.

#### Changes
- Replaced the hardcoded module include path (`/home/sch/...`) with a `$HOME`-based path.
- Commented out **Bar 2**, which depended on a specific display output (`DP-2`).
- Commented explicit `output` configuration to avoid display name assumptions.

#### Rationale
Hardcoded home directories and output names reduce reusability and can cause configuration issues on different machines. These changes make the configuration safer to use on generic systems without manual edits.

#### Impact
- Improves portability and maintainability
- Prevents startup issues on systems with different users or monitor layouts
- No functional change for setups using only Bar 1
